### PR TITLE
Update the OrderClient endpoint and respective models

### DIFF
--- a/KalshiSharp.Tests/Orders/OrderClientTests.cs
+++ b/KalshiSharp.Tests/Orders/OrderClientTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using KalshiSharp.Auth;
 using KalshiSharp.Tests.Auth;
@@ -76,19 +77,33 @@ public sealed class OrderClientTests : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""
                 {
-                    "order_id": "order-12345",
-                    "ticker": "MARKET-ABC",
-                    "side": "yes",
-                    "type": "limit",
-                    "status": "resting",
-                    "action": "buy",
-                    "fill_count": 0,
-                    "initial_count": 10,
-                    "remaining_count": 10,
-                    "yes_price": 55,
-                    "no_price": 45,
-                    "time_in_force": "gtc",
-                    "created_time": 1704067200000
+                    "order": {
+                        "order_id": "order-12345",
+                        "user_id": "user-abc",
+                        "client_order_id": "client-001",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "fill_count_fp": "0.00",
+                        "initial_count_fp": "10.00",
+                        "remaining_count_fp": "10.00",
+                        "yes_price_dollars": "0.55",
+                        "no_price_dollars": "0.45",
+                        "taker_fill_cost_dollars": "0.00",
+                        "maker_fill_cost_dollars": "0.00",
+                        "taker_fees_dollars": "0.00",
+                        "maker_fees_dollars": "0.00",
+                        "queue_position": 1,
+                        "created_time": "2024-01-01T00:00:00Z",
+                        "expiration_time": "2024-12-31T23:59:59Z",
+                        "self_trade_prevention_type": "cancel_resting",
+                        "order_group_id": "group-xyz",
+                        "cancel_order_on_pause": false,
+                        "outcome_side": "yes",
+                        "book_side": "bid"
+                    }
                 }
                 """));
 
@@ -97,9 +112,15 @@ public sealed class OrderClientTests : IDisposable
             Ticker = "MARKET-ABC",
             Side = OrderSide.Yes,
             Action = "buy",
-            Count = 10,
+            CountFp = "10.00",
             Type = OrderType.Limit,
-            YesPrice = 55
+            YesPriceDollars = "0.55",
+            NoPriceDollars = null,
+            TimeInForce = TimeInForce.GoodTillCanceled,
+            ExpirationTime = new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero),
+            ClientOrderId = "client-001",
+            SellPositionFloor = false,
+            BuyMaxCost = false
         };
 
         // Act
@@ -108,15 +129,30 @@ public sealed class OrderClientTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.OrderId.Should().Be("order-12345");
+        result.UserId.Should().Be("user-abc");
+        result.ClientOrderId.Should().Be("client-001");
         result.Ticker.Should().Be("MARKET-ABC");
         result.Side.Should().Be(OrderSide.Yes);
         result.Type.Should().Be(OrderType.Limit);
         result.Status.Should().Be(OrderStatus.Resting);
         result.Action.Should().Be("buy");
-        result.InitialCount.Should().Be(10);
-        result.RemainingCount.Should().Be(10);
-        result.YesPrice.Should().Be(55);
-        result.NoPrice.Should().Be(45);
+        result.FillCountFp.Should().Be("0.00");
+        result.InitialCountFp.Should().Be("10.00");
+        result.RemainingCountFp.Should().Be("10.00");
+        result.YesPriceDollars.Should().Be("0.55");
+        result.NoPriceDollars.Should().Be("0.45");
+        result.TakerFillCostDollars.Should().Be("0.00");
+        result.MakerFillCostDollars.Should().Be("0.00");
+        result.TakerFeesDollars.Should().Be("0.00");
+        result.MakerFeesDollars.Should().Be("0.00");
+        result.QueuePosition.Should().Be(1);
+        result.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        result.ExpirationTime.Should().Be(new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero));
+        result.SelfTradePreventionType.Should().Be("cancel_resting");
+        result.OrderGroupId.Should().Be("group-xyz");
+        result.CancelOrderOnPause.Should().BeFalse();
+        result.OutcomeSide.Should().Be(OrderSide.Yes);
+        result.BookSide.Should().Be(OrderBookSide.Bid);
     }
 
     [Fact]
@@ -143,9 +179,9 @@ public sealed class OrderClientTests : IDisposable
             Ticker = "MARKET-ABC",
             Side = OrderSide.Yes,
             Action = "buy",
-            Count = -1,
+            CountFp = "-1.00",
             Type = OrderType.Limit,
-            YesPrice = 55
+            YesPriceDollars = "0.55"
         };
 
         // Act & Assert
@@ -161,34 +197,70 @@ public sealed class OrderClientTests : IDisposable
         // Arrange
         const string orderId = "order-12345";
         _server.Given(Request.Create()
-                .WithPath($"/trade-api/v2/portfolio/orders/{orderId}")
-                .UsingPut())
+                .WithPath($"/trade-api/v2/portfolio/orders/{orderId}/amend")
+                .UsingPost())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""
                 {
-                    "order_id": "order-12345",
-                    "ticker": "MARKET-ABC",
-                    "side": "yes",
-                    "type": "limit",
-                    "status": "resting",
-                    "action": "buy",
-                    "fill_count": 0,
-                    "initial_count": 15,
-                    "remaining_count": 15,
-                    "yes_price": 60,
-                    "no_price": 40,
-                    "time_in_force": "gtc",
-                    "created_time": 1704067200000,
-                    "last_update_time": 1704067300000
+                    "old_order": {
+                        "order_id": "order-12345",
+                        "user_id": "user-abc",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "fill_count_fp": "0.00",
+                        "initial_count_fp": "10.00",
+                        "remaining_count_fp": "10.00",
+                        "yes_price_dollars": "0.55",
+                        "no_price_dollars": "0.45",
+                        "taker_fill_cost_dollars": "0.00",
+                        "maker_fill_cost_dollars": "0.00",
+                        "taker_fees_dollars": "0.00",
+                        "maker_fees_dollars": "0.00",
+                        "queue_position": 3,
+                        "created_time": "2024-01-01T00:00:00Z",
+                        "outcome_side": "yes",
+                        "book_side": "bid"
+                    },
+                    "order": {
+                        "order_id": "order-12345",
+                        "user_id": "user-abc",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "fill_count_fp": "0.00",
+                        "initial_count_fp": "15.00",
+                        "remaining_count_fp": "15.00",
+                        "yes_price_dollars": "0.60",
+                        "no_price_dollars": "0.40",
+                        "taker_fill_cost_dollars": "0.00",
+                        "maker_fill_cost_dollars": "0.00",
+                        "taker_fees_dollars": "0.00",
+                        "maker_fees_dollars": "0.00",
+                        "queue_position": 1,
+                        "created_time": "2024-01-01T00:00:00Z",
+                        "last_update_time": "2024-01-01T00:05:00Z",
+                        "cancel_order_on_pause": true,
+                        "outcome_side": "yes",
+                        "book_side": "bid"
+                    }
                 }
                 """));
 
         var request = new AmendOrderRequest
         {
-            Price = 60,
-            Count = 15
+            Ticker = "MARKET-ABC",
+            Side = OrderSide.Yes,
+            Action = "buy",
+            YesPriceDollars = "0.60",
+            NoPriceDollars = null,
+            CountFp = "15.00"
         };
 
         // Act
@@ -196,17 +268,60 @@ public sealed class OrderClientTests : IDisposable
 
         // Assert
         result.Should().NotBeNull();
-        result.OrderId.Should().Be("order-12345");
-        result.InitialCount.Should().Be(15);
-        result.YesPrice.Should().Be(60);
-        result.LastUpdateTime.Should().NotBeNull();
+        result.OldOrder.Should().NotBeNull();
+        result.Order.Should().NotBeNull();
+
+        result.OldOrder.OrderId.Should().Be("order-12345");
+        result.OldOrder.UserId.Should().Be("user-abc");
+        result.OldOrder.Ticker.Should().Be("MARKET-ABC");
+        result.OldOrder.Side.Should().Be(OrderSide.Yes);
+        result.OldOrder.Type.Should().Be(OrderType.Limit);
+        result.OldOrder.Status.Should().Be(OrderStatus.Resting);
+        result.OldOrder.Action.Should().Be("buy");
+        result.OldOrder.FillCountFp.Should().Be("0.00");
+        result.OldOrder.InitialCountFp.Should().Be("10.00");
+        result.OldOrder.RemainingCountFp.Should().Be("10.00");
+        result.OldOrder.YesPriceDollars.Should().Be("0.55");
+        result.OldOrder.NoPriceDollars.Should().Be("0.45");
+        result.OldOrder.TakerFillCostDollars.Should().Be("0.00");
+        result.OldOrder.MakerFillCostDollars.Should().Be("0.00");
+        result.OldOrder.TakerFeesDollars.Should().Be("0.00");
+        result.OldOrder.MakerFeesDollars.Should().Be("0.00");
+        result.OldOrder.QueuePosition.Should().Be(3);
+        result.OldOrder.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        result.OldOrder.OutcomeSide.Should().Be(OrderSide.Yes);
+        result.OldOrder.BookSide.Should().Be(OrderBookSide.Bid);
+
+        result.Order.OrderId.Should().Be("order-12345");
+        result.Order.UserId.Should().Be("user-abc");
+        result.Order.FillCountFp.Should().Be("0.00");
+        result.Order.InitialCountFp.Should().Be("15.00");
+        result.Order.RemainingCountFp.Should().Be("15.00");
+        result.Order.YesPriceDollars.Should().Be("0.60");
+        result.Order.NoPriceDollars.Should().Be("0.40");
+        result.Order.TakerFillCostDollars.Should().Be("0.00");
+        result.Order.MakerFillCostDollars.Should().Be("0.00");
+        result.Order.TakerFeesDollars.Should().Be("0.00");
+        result.Order.MakerFeesDollars.Should().Be("0.00");
+        result.Order.QueuePosition.Should().Be(1);
+        result.Order.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        result.Order.LastUpdateTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 5, 0, TimeSpan.Zero));
+        result.Order.CancelOrderOnPause.Should().BeTrue();
+        result.Order.OutcomeSide.Should().Be(OrderSide.Yes);
+        result.Order.BookSide.Should().Be(OrderBookSide.Bid);
     }
 
     [Fact]
     public async Task AmendOrderAsync_WithEmptyOrderId_ThrowsArgumentException()
     {
         // Arrange
-        var request = new AmendOrderRequest { Price = 60 };
+        var request = new AmendOrderRequest 
+        { 
+            Ticker = "MARKET-ABC",
+            Side = OrderSide.No,
+            Action = "sell",
+            NoPriceDollars = "0.60"
+        };
 
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() => _client.AmendOrderAsync("", request));
@@ -233,20 +348,28 @@ public sealed class OrderClientTests : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""
                 {
-                    "order_id": "order-12345",
-                    "ticker": "MARKET-ABC",
-                    "side": "yes",
-                    "type": "limit",
-                    "status": "canceled",
-                    "action": "buy",
-                    "fill_count": 0,
-                    "initial_count": 10,
-                    "remaining_count": 10,
-                    "yes_price": 55,
-                    "no_price": 45,
-                    "time_in_force": "gtc",
-                    "created_time": 1704067200000,
-                    "last_update_time": 1704067200000
+                    "order": {
+                        "order_id": "order-12345",
+                        "user_id": "user-abc",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "canceled",
+                        "action": "buy",
+                        "fill_count_fp": "0.00",
+                        "initial_count_fp": "10.00",
+                        "remaining_count_fp": "10.00",
+                        "yes_price_dollars": "0.55",
+                        "no_price_dollars": "0.45",
+                        "taker_fill_cost_dollars": "0.00",
+                        "maker_fill_cost_dollars": "0.00",
+                        "taker_fees_dollars": "0.00",
+                        "maker_fees_dollars": "0.00",
+                        "created_time": "2024-01-01T00:00:00Z",
+                        "last_update_time": "2024-01-01T00:10:00Z",
+                        "outcome_side": "yes",
+                        "book_side": "bid"
+                    }
                 }
                 """));
 
@@ -256,7 +379,25 @@ public sealed class OrderClientTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.OrderId.Should().Be("order-12345");
+        result.UserId.Should().Be("user-abc");
+        result.Ticker.Should().Be("MARKET-ABC");
+        result.Side.Should().Be(OrderSide.Yes);
+        result.Type.Should().Be(OrderType.Limit);
         result.Status.Should().Be(OrderStatus.Canceled);
+        result.Action.Should().Be("buy");
+        result.FillCountFp.Should().Be("0.00");
+        result.InitialCountFp.Should().Be("10.00");
+        result.RemainingCountFp.Should().Be("10.00");
+        result.YesPriceDollars.Should().Be("0.55");
+        result.NoPriceDollars.Should().Be("0.45");
+        result.TakerFillCostDollars.Should().Be("0.00");
+        result.MakerFillCostDollars.Should().Be("0.00");
+        result.TakerFeesDollars.Should().Be("0.00");
+        result.MakerFeesDollars.Should().Be("0.00");
+        result.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        result.LastUpdateTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 10, 0, TimeSpan.Zero));
+        result.OutcomeSide.Should().Be(OrderSide.Yes);
+        result.BookSide.Should().Be(OrderBookSide.Bid);
     }
 
     [Fact]
@@ -299,21 +440,32 @@ public sealed class OrderClientTests : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""
                 {
-                    "order_id": "order-12345",
-                    "client_order_id": "client-order-abc",
-                    "ticker": "MARKET-ABC",
-                    "side": "no",
-                    "type": "market",
-                    "status": "executed",
-                    "action": "sell",
-                    "fill_count": 5,
-                    "initial_count": 5,
-                    "remaining_count": 0,
-                    "yes_price": 45,
-                    "no_price": 55,
-                    "time_in_force": "ioc",
-                    "created_time": 1704067200000,
-                    "fees_paid": 10
+                    "order": {
+                        "order_id": "order-12345",
+                        "user_id": "user-abc",
+                        "client_order_id": "client-order-abc",
+                        "ticker": "MARKET-ABC",
+                        "side": "no",
+                        "type": "market",
+                        "status": "executed",
+                        "action": "sell",
+                        "fill_count_fp": "5.00",
+                        "initial_count_fp": "5.00",
+                        "remaining_count_fp": "0.00",
+                        "yes_price_dollars": "0.45",
+                        "no_price_dollars": "0.55",
+                        "taker_fill_cost_dollars": "2.75",
+                        "maker_fill_cost_dollars": "0.00",
+                        "taker_fees_dollars": "0.03",
+                        "maker_fees_dollars": "0.00",
+                        "created_time": "2024-01-01T00:00:00Z",
+                        "last_update_time": "2024-01-01T00:01:00Z",
+                        "self_trade_prevention_type": "cancel_resting",
+                        "order_group_id": "group-abc",
+                        "cancel_order_on_pause": true,
+                        "outcome_side": "no",
+                        "book_side": "ask"
+                    }
                 }
                 """));
 
@@ -323,15 +475,29 @@ public sealed class OrderClientTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.OrderId.Should().Be("order-12345");
+        result.UserId.Should().Be("user-abc");
         result.ClientOrderId.Should().Be("client-order-abc");
         result.Ticker.Should().Be("MARKET-ABC");
         result.Side.Should().Be(OrderSide.No);
         result.Type.Should().Be(OrderType.Market);
         result.Status.Should().Be(OrderStatus.Executed);
         result.Action.Should().Be("sell");
-        result.InitialCount.Should().Be(5);
-        result.RemainingCount.Should().Be(0);
-        result.FillCount.Should().Be(5);
+        result.FillCountFp.Should().Be("5.00");
+        result.InitialCountFp.Should().Be("5.00");
+        result.RemainingCountFp.Should().Be("0.00");
+        result.YesPriceDollars.Should().Be("0.45");
+        result.NoPriceDollars.Should().Be("0.55");
+        result.TakerFillCostDollars.Should().Be("2.75");
+        result.MakerFillCostDollars.Should().Be("0.00");
+        result.TakerFeesDollars.Should().Be("0.03");
+        result.MakerFeesDollars.Should().Be("0.00");
+        result.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        result.LastUpdateTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 1, 0, TimeSpan.Zero));
+        result.SelfTradePreventionType.Should().Be("cancel_resting");
+        result.OrderGroupId.Should().Be("group-abc");
+        result.CancelOrderOnPause.Should().BeTrue();
+        result.OutcomeSide.Should().Be(OrderSide.No);
+        result.BookSide.Should().Be(OrderBookSide.Ask);
     }
 
     [Fact]
@@ -373,33 +539,49 @@ public sealed class OrderClientTests : IDisposable
                     "orders": [
                         {
                             "order_id": "order-001",
+                            "user_id": "user-abc",
                             "ticker": "MARKET-1",
                             "side": "yes",
                             "type": "limit",
                             "status": "resting",
                             "action": "buy",
-                            "fill_count": 5,
-                            "initial_count": 10,                            
-                            "remaining_count": 5,
-                            "yes_price": 50,
-                            "no_price": 50,
-                            "time_in_force": "gtc",
-                            "created_time": 1704067200000
+                            "fill_count_fp": "5.00",
+                            "initial_count_fp": "10.00",
+                            "remaining_count_fp": "5.00",
+                            "yes_price_dollars": "0.50",
+                            "no_price_dollars": "0.50",
+                            "taker_fill_cost_dollars": "2.50",
+                            "maker_fill_cost_dollars": "0.00",
+                            "taker_fees_dollars": "0.03",
+                            "maker_fees_dollars": "0.00",
+                            "queue_position": 2,
+                            "created_time": "2024-01-01T00:00:00Z",
+                            "self_trade_prevention_type": "cancel_resting",
+                            "cancel_order_on_pause": false,
+                            "outcome_side": "yes",
+                            "book_side": "bid"
                         },
                         {
                             "order_id": "order-002",
+                            "user_id": "user-abc",
                             "ticker": "MARKET-2",
                             "side": "no",
                             "type": "limit",
                             "status": "resting",
                             "action": "buy",
-                            "fill_count": 0,
-                            "initial_count": 20,
-                            "remaining_count": 20,
-                            "yes_price": 40,
-                            "no_price": 60,
-                            "time_in_force": "gtc",
-                            "created_time": 1704067300000
+                            "fill_count_fp": "0.00",
+                            "initial_count_fp": "20.00",
+                            "remaining_count_fp": "20.00",
+                            "yes_price_dollars": "0.40",
+                            "no_price_dollars": "0.60",
+                            "taker_fill_cost_dollars": "0.00",
+                            "maker_fill_cost_dollars": "0.00",
+                            "taker_fees_dollars": "0.00",
+                            "maker_fees_dollars": "0.00",
+                            "queue_position": 5,
+                            "created_time": "2024-01-01T00:01:40Z",
+                            "outcome_side": "no",
+                            "book_side": "ask"
                         }
                     ],
                     "cursor": "next-page-cursor"
@@ -412,11 +594,39 @@ public sealed class OrderClientTests : IDisposable
         // Assert
         result.Should().NotBeNull();
         result.Items.Should().HaveCount(2);
-        result.Items[0].OrderId.Should().Be("order-001");
-        result.Items[0].FillCount.Should().Be(5);
-        result.Items[1].OrderId.Should().Be("order-002");
         result.Cursor.Should().Be("next-page-cursor");
         result.HasMore.Should().BeTrue();
+
+        var first = result.Items[0];
+        first.OrderId.Should().Be("order-001");
+        first.UserId.Should().Be("user-abc");
+        first.Ticker.Should().Be("MARKET-1");
+        first.Side.Should().Be(OrderSide.Yes);
+        first.Type.Should().Be(OrderType.Limit);
+        first.Status.Should().Be(OrderStatus.Resting);
+        first.Action.Should().Be("buy");
+        first.FillCountFp.Should().Be("5.00");
+        first.InitialCountFp.Should().Be("10.00");
+        first.RemainingCountFp.Should().Be("5.00");
+        first.YesPriceDollars.Should().Be("0.50");
+        first.NoPriceDollars.Should().Be("0.50");
+        first.TakerFillCostDollars.Should().Be("2.50");
+        first.MakerFillCostDollars.Should().Be("0.00");
+        first.TakerFeesDollars.Should().Be("0.03");
+        first.MakerFeesDollars.Should().Be("0.00");
+        first.QueuePosition.Should().Be(2);
+        first.CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        first.SelfTradePreventionType.Should().Be("cancel_resting");
+        first.CancelOrderOnPause.Should().BeFalse();
+        first.OutcomeSide.Should().Be(OrderSide.Yes);
+        first.BookSide.Should().Be(OrderBookSide.Bid);
+
+        var second = result.Items[1];
+        second.OrderId.Should().Be("order-002");
+        second.FillCountFp.Should().Be("0.00");
+        second.QueuePosition.Should().Be(5);
+        second.OutcomeSide.Should().Be(OrderSide.No);
+        second.BookSide.Should().Be(OrderBookSide.Ask);
     }
 
     [Fact]
@@ -471,18 +681,25 @@ public sealed class OrderClientTests : IDisposable
                     "orders": [
                         {
                             "order_id": "order-003",
+                            "user_id": "user-abc",
                             "ticker": "MARKET-3",
                             "side": "yes",
                             "type": "limit",
                             "status": "canceled",
                             "action": "buy",
-                            "fill_count": 0,
-                            "initial_count": 5,
-                            "remaining_count": 5,
-                            "yes_price": 70,
-                            "no_price": 30,
-                            "time_in_force": "gtc",
-                            "created_time": 1704067400000
+                            "fill_count_fp": "0.00",
+                            "initial_count_fp": "5.00",
+                            "remaining_count_fp": "5.00",
+                            "yes_price_dollars": "0.70",
+                            "no_price_dollars": "0.30",
+                            "taker_fill_cost_dollars": "0.00",
+                            "maker_fill_cost_dollars": "0.00",
+                            "taker_fees_dollars": "0.00",
+                            "maker_fees_dollars": "0.00",
+                            "created_time": "2024-01-01T00:03:20Z",
+                            "last_update_time": "2024-01-01T00:04:00Z",
+                            "outcome_side": "yes",
+                            "book_side": "bid"
                         }
                     ],
                     "cursor": null
@@ -499,6 +716,10 @@ public sealed class OrderClientTests : IDisposable
         result.Items.Should().HaveCount(1);
         result.Items[0].OrderId.Should().Be("order-003");
         result.Items[0].Status.Should().Be(OrderStatus.Canceled);
+        result.Items[0].CreatedTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 3, 20, TimeSpan.Zero));
+        result.Items[0].LastUpdateTime.Should().Be(new DateTimeOffset(2024, 1, 1, 0, 4, 0, TimeSpan.Zero));
+        result.Items[0].OutcomeSide.Should().Be(OrderSide.Yes);
+        result.Items[0].BookSide.Should().Be(OrderBookSide.Bid);
         result.HasMore.Should().BeFalse();
     }
 
@@ -542,20 +763,20 @@ public sealed class OrderClientTests : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""
                 {
-                    "order_id": "order-99999",
-                    "client_order_id": "my-custom-id",
-                    "ticker": "MARKET-TEST",
-                    "side": "yes",
-                    "type": "limit",
-                    "status": "resting",
-                    "action": "buy",
-                    "fill_count": 0,
-                    "initial_count": 1,
-                    "remaining_count": 1,
-                    "yes_price": 50,
-                    "no_price": 50,
-                    "time_in_force": "gtc",
-                    "created_time": 1704067200000
+                    "order": {
+                        "order_id": "order-99999",
+                        "client_order_id": "my-custom-id",
+                        "ticker": "MARKET-TEST",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "fill_count_fp": "0.00",
+                        "initial_count_fp": "1.00",
+                        "remaining_count_fp": "1.00",
+                        "yes_price_dollars": "0.50",
+                        "no_price_dollars": "0.50"
+                    }
                 }
                 """));
 
@@ -564,9 +785,9 @@ public sealed class OrderClientTests : IDisposable
             Ticker = "MARKET-TEST",
             Side = OrderSide.Yes,
             Action = "buy",
-            Count = 1,
+            CountFp = "1.00",
             Type = OrderType.Limit,
-            YesPrice = 50,
+            YesPriceDollars = "0.50",
             ClientOrderId = "my-custom-id"
         };
 
@@ -595,14 +816,255 @@ public sealed class OrderClientTests : IDisposable
             Ticker = "MARKET-ABC",
             Side = OrderSide.Yes,
             Action = "buy",
-            Count = 10,
+            CountFp = "10.00",
             Type = OrderType.Limit,
-            YesPrice = 55
+            YesPriceDollars = "0.55"
         };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<KalshiAuthException>(
             () => _client.CreateOrderAsync(request));
+
+        exception.ErrorCode.Should().Be("unauthorized");
+    }
+
+    [Fact]
+    public async Task CreateOrderAsync_ServerError_ThrowsKalshiException()
+    {
+        // Arrange
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"code":"internal_error","message":"Internal server error"}"""));
+
+        var request = new CreateOrderRequest
+        {
+            Ticker = "MARKET-ABC",
+            Side = OrderSide.Yes,
+            Action = "buy",
+            CountFp = "10.00",
+            Type = OrderType.Limit,
+            YesPriceDollars = "0.55"
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<KalshiException>(() => _client.CreateOrderAsync(request));
+    }
+
+    [Fact]
+    public async Task GetOrderAsync_RestingOrder_HasQueuePosition()
+    {
+        // Arrange
+        const string orderId = "order-resting";
+        _server.Given(Request.Create()
+                .WithPath($"/trade-api/v2/portfolio/orders/{orderId}")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""
+                {
+                    "order": {
+                        "order_id": "order-resting",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "queue_position": 7
+                    }
+                }
+                """));
+
+        // Act
+        var result = await _client.GetOrderAsync(orderId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(OrderStatus.Resting);
+        result.QueuePosition.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task GetOrderAsync_WithOrderGroupId_ReturnsGroupId()
+    {
+        // Arrange
+        const string orderId = "order-grouped";
+        _server.Given(Request.Create()
+                .WithPath($"/trade-api/v2/portfolio/orders/{orderId}")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""
+                {
+                    "order": {
+                        "order_id": "order-grouped",
+                        "ticker": "MARKET-ABC",
+                        "side": "yes",
+                        "type": "limit",
+                        "status": "resting",
+                        "action": "buy",
+                        "order_group_id": "batch-group-001"
+                    }
+                }
+                """));
+
+        // Act
+        var result = await _client.GetOrderAsync(orderId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.OrderGroupId.Should().Be("batch-group-001");
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_WithMinTsFilter_IncludesQueryParam()
+    {
+        // Arrange
+        var minTs = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expectedParam = minTs.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .WithParam("min_ts", expectedParam)
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"orders": [], "cursor": null}"""));
+
+        var query = new OrderQuery { MinTs = minTs };
+
+        // Act
+        var result = await _client.ListOrdersAsync(query);
+
+        // Assert
+        result.Should().NotBeNull();
+        _server.LogEntries.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_WithMaxTsFilter_IncludesQueryParam()
+    {
+        // Arrange
+        var maxTs = new DateTimeOffset(2024, 6, 30, 23, 59, 59, TimeSpan.Zero);
+        var expectedParam = maxTs.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .WithParam("max_ts", expectedParam)
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"orders": [], "cursor": null}"""));
+
+        var query = new OrderQuery { MaxTs = maxTs };
+
+        // Act
+        var result = await _client.ListOrdersAsync(query);
+
+        // Assert
+        result.Should().NotBeNull();
+        _server.LogEntries.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_WithAllFilters_IncludesAllQueryParams()
+    {
+        // Arrange
+        var minTs = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var maxTs = new DateTimeOffset(2024, 12, 31, 23, 59, 59, TimeSpan.Zero);
+
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .WithParam("status", "resting")
+                .WithParam("ticker", "MARKET-XYZ")
+                .WithParam("event_ticker", "EVENT-123")
+                .WithParam("limit", "25")
+                .WithParam("cursor", "some-cursor")
+                .WithParam("min_ts", minTs.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture))
+                .WithParam("max_ts", maxTs.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture))
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"orders": [], "cursor": null}"""));
+
+        var query = new OrderQuery
+        {
+            Status = OrderStatus.Resting,
+            Ticker = "MARKET-XYZ",
+            EventTicker = "EVENT-123",
+            Limit = 25,
+            Cursor = "some-cursor",
+            MinTs = minTs,
+            MaxTs = maxTs
+        };
+
+        // Act
+        var result = await _client.ListOrdersAsync(query);
+
+        // Assert
+        result.Should().NotBeNull();
+        _server.LogEntries.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_NullCursor_HasMoreIsFalse()
+    {
+        // Arrange
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""
+                {
+                    "orders": [
+                        {
+                            "order_id": "order-last",
+                            "ticker": "MARKET-1",
+                            "side": "yes",
+                            "type": "limit",
+                            "status": "resting",
+                            "action": "buy"
+                        }
+                    ],
+                    "cursor": null
+                }
+                """));
+
+        // Act
+        var result = await _client.ListOrdersAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Items.Should().HaveCount(1);
+        result.Cursor.Should().BeNull();
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListOrdersAsync_Unauthorized_ThrowsAuthException()
+    {
+        // Arrange
+        _server.Given(Request.Create()
+                .WithPath("/trade-api/v2/portfolio/orders")
+                .UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(401)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"code":"unauthorized","message":"Invalid API key"}"""));
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<KalshiAuthException>(
+            () => _client.ListOrdersAsync());
 
         exception.ErrorCode.Should().Be("unauthorized");
     }

--- a/KalshiSharp/Models/Enums/OrderBookSide.cs
+++ b/KalshiSharp/Models/Enums/OrderBookSide.cs
@@ -1,0 +1,22 @@
+namespace KalshiSharp.Models.Enums;
+
+/// <summary>
+/// Represents the side of the order book for a V2 order.
+/// </summary>
+/// <remarks>
+/// Serialized as lowercase strings: "bid", "ask".
+/// For event markets, this refers to the YES leg only: bid means buy YES, ask means sell YES.
+/// Selling YES is economically equivalent to buying NO at 1 - price.
+/// </remarks>
+public enum OrderBookSide
+{
+    /// <summary>
+    /// Bid — buy YES contracts.
+    /// </summary>
+    Bid,
+
+    /// <summary>
+    /// Ask — sell YES contracts (equivalent to buying NO at 1 - price).
+    /// </summary>
+    Ask
+}

--- a/KalshiSharp/Models/Enums/PeriodInterval.cs
+++ b/KalshiSharp/Models/Enums/PeriodInterval.cs
@@ -1,0 +1,9 @@
+﻿namespace KalshiSharp.Models.Enums
+{
+    public enum PeriodInterval
+    {
+        OneMinute = 1,
+        OneHour = 60,
+        OnDay = 1440
+    }
+}

--- a/KalshiSharp/Models/Enums/SelfTradePreventionType.cs
+++ b/KalshiSharp/Models/Enums/SelfTradePreventionType.cs
@@ -1,0 +1,21 @@
+namespace KalshiSharp.Models.Enums;
+
+/// <summary>
+/// Represents the self-trade prevention strategy for a V2 order.
+/// </summary>
+/// <remarks>
+/// Serialized as snake_case strings: "taker_at_cross", "maker".
+/// </remarks>
+public enum SelfTradePreventionType
+{
+    /// <summary>
+    /// Cancels the incoming taker order when it would trade against another order from the same user.
+    /// Any partial fills already matched are executed.
+    /// </summary>
+    TakerAtCross,
+
+    /// <summary>
+    /// Cancels the resting maker order and continues matching.
+    /// </summary>
+    Maker
+}

--- a/KalshiSharp/Models/Enums/TimeInForce.cs
+++ b/KalshiSharp/Models/Enums/TimeInForce.cs
@@ -11,15 +11,15 @@ public enum TimeInForce
     /// <summary>
     /// Good Till Cancelled - order remains active until explicitly cancelled.
     /// </summary>
-    Gtc,
+    GoodTillCanceled,
 
     /// <summary>
     /// Immediate Or Cancel - execute immediately and cancel any unfilled portion.
     /// </summary>
-    Ioc,
+    ImmediateOrCancel,
 
     /// <summary>
     /// Fill Or Kill - execute entire order immediately or cancel completely.
     /// </summary>
-    Fok
+    FillOrKill
 }

--- a/KalshiSharp/Models/Requests/AmendOrderRequest.cs
+++ b/KalshiSharp/Models/Requests/AmendOrderRequest.cs
@@ -1,3 +1,6 @@
+using KalshiSharp.Models.Enums;
+using System.Text.Json.Serialization;
+
 namespace KalshiSharp.Models.Requests;
 
 /// <summary>
@@ -10,12 +13,35 @@ namespace KalshiSharp.Models.Requests;
 public sealed record AmendOrderRequest
 {
     /// <summary>
-    /// The new price in cents (1-99).
+    /// Market ticker.
     /// </summary>
-    public int? Price { get; init; }
+    public required string Ticker { get; init; }
 
     /// <summary>
-    /// The new quantity (total contracts).
+    /// Side of the order.
     /// </summary>
-    public int? Count { get; init; }
+    public required OrderSide Side { get; init; }
+
+    /// <summary>
+    /// Action of the order
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Updated yes price for the order in dollars
+    /// </summary>
+    [JsonPropertyName("yes_price_dollars")]
+    public string? YesPriceDollars { get; init; }
+
+    /// <summary>
+    /// Updated no price for the order in dollars
+    /// </summary>
+    [JsonPropertyName("no_price_dollars")]
+    public string? NoPriceDollars { get; init; }
+
+    /// <summary>
+    /// The new quantity (total contracts) - Fixed-point (2 decimals).
+    /// </summary>
+    [JsonPropertyName("count_fp")]
+    public string? CountFp { get; init; }
 }

--- a/KalshiSharp/Models/Requests/AmendOrderRequestV2.cs
+++ b/KalshiSharp/Models/Requests/AmendOrderRequestV2.cs
@@ -1,0 +1,45 @@
+using KalshiSharp.Models.Enums;
+
+namespace KalshiSharp.Models.Requests;
+
+/// <summary>
+/// Request to amend an existing order via the V2 events orders endpoint.
+/// </summary>
+public sealed record AmendOrderRequestV2
+{
+    /// <summary>
+    /// The market ticker of the order to amend.
+    /// </summary>
+    public required string Ticker { get; init; }
+
+    /// <summary>
+    /// Side of the order.
+    /// </summary>
+    public required OrderBookSide Side { get; init; }
+
+    /// <summary>
+    /// Updated price for the order in fixed-point dollars (e.g. "0.5600").
+    /// </summary>
+    public required string Price { get; init; }
+
+    /// <summary>
+    /// Updated total/max fillable count for the order.
+    /// Set to the order's already filled count plus the desired resting remaining count after the amend (e.g. "10.00").
+    /// </summary>
+    public required string Count { get; init; }
+
+    /// <summary>
+    /// The original client-specified order ID to be amended.
+    /// </summary>
+    public string? ClientOrderId { get; init; }
+
+    /// <summary>
+    /// The new client-specified order ID after amendment.
+    /// </summary>
+    public string? UpdatedClientOrderId { get; init; }
+
+    /// <summary>
+    /// Identifier for an exchange shard. Defaults to 0 if unspecified.
+    /// </summary>
+    public int? ExchangeIndex { get; init; }
+}

--- a/KalshiSharp/Models/Requests/CancelOrderQueryV2.cs
+++ b/KalshiSharp/Models/Requests/CancelOrderQueryV2.cs
@@ -1,0 +1,31 @@
+using KalshiSharp.Models.Common;
+
+namespace KalshiSharp.Models.Requests;
+
+/// <summary>
+/// Optional query parameters for cancelling a V2 order.
+/// </summary>
+public sealed record CancelOrderQueryV2
+{
+    /// <summary>
+    /// Subaccount number (0 for primary, 1-63 for subaccounts). Defaults to 0.
+    /// </summary>
+    public int? Subaccount { get; init; }
+
+    /// <summary>
+    /// Identifier for an exchange shard. Defaults to 0 if unspecified.
+    /// </summary>
+    public int? ExchangeIndex { get; init; }
+
+    /// <summary>
+    /// Builds the query string for the API request.
+    /// </summary>
+    /// <returns>The query string including the leading '?' if parameters exist.</returns>
+    public string ToQueryString()
+    {
+        var builder = new QueryStringBuilder();
+        builder.AppendIfNotNull("subaccount", Subaccount);
+        builder.AppendIfNotNull("exchange_index", ExchangeIndex);
+        return builder.Build();
+    }
+}

--- a/KalshiSharp/Models/Requests/CreateOrderRequest.cs
+++ b/KalshiSharp/Models/Requests/CreateOrderRequest.cs
@@ -1,4 +1,5 @@
 using KalshiSharp.Models.Enums;
+using System.Text.Json.Serialization;
 
 namespace KalshiSharp.Models.Requests;
 
@@ -20,27 +21,30 @@ public sealed record CreateOrderRequest
     /// <summary>
     /// The action to take (buy or sell).
     /// </summary>
-    public required string Action { get; init; }
+    public required string Action { get; init; }   
 
     /// <summary>
-    /// The number of contracts to buy/sell.
+    /// The number of contracts to buy/sell - Fixed-point (2 decimals).
     /// </summary>
-    public required int Count { get; init; }
+    [JsonPropertyName("count_fp")]
+    public required string CountFp { get; init; }
+
+    /// <summary>
+    /// The limit price in dollars. Required for limit orders on Yes side.
+    /// </summary>
+    [JsonPropertyName("yes_price_dollars")]
+    public string? YesPriceDollars { get; init; }
+
+    /// <summary>
+    /// The no price in dollars. Required for limit orders on No side.
+    /// </summary>
+    [JsonPropertyName("no_price_dollars")]
+    public string? NoPriceDollars { get; init; }
 
     /// <summary>
     /// The order type (Limit or Market).
     /// </summary>
     public required OrderType Type { get; init; }
-
-    /// <summary>
-    /// The limit price in cents (1-99). Required for limit orders.
-    /// </summary>
-    public int? YesPrice { get; init; }
-
-    /// <summary>
-    /// The no price in cents. Derived from yes price if not specified.
-    /// </summary>
-    public int? NoPrice { get; init; }
 
     /// <summary>
     /// Time in force for the order. Defaults to GTC.

--- a/KalshiSharp/Models/Requests/CreateOrderRequestV2.cs
+++ b/KalshiSharp/Models/Requests/CreateOrderRequestV2.cs
@@ -1,0 +1,83 @@
+using KalshiSharp.Models.Enums;
+
+namespace KalshiSharp.Models.Requests;
+
+/// <summary>
+/// Request to create a new order via the V2 events orders endpoint.
+/// </summary>
+public sealed record CreateOrderRequestV2
+{
+    /// <summary>
+    /// The market ticker to place the order on.
+    /// </summary>
+    public required string Ticker { get; init; }
+
+    /// <summary>
+    /// Side of the book. For event markets, this refers to the YES leg only:
+    /// bid means buy YES, ask means sell YES.
+    /// </summary>
+    public required OrderBookSide Side { get; init; }
+
+    /// <summary>
+    /// String representation of the order quantity in contracts (e.g. "10.00").
+    /// </summary>
+    public required string Count { get; init; }
+
+    /// <summary>
+    /// Price for the order in fixed-point dollars (e.g. "0.5600").
+    /// </summary>
+    public required string Price { get; init; }
+
+    /// <summary>
+    /// Specifies how long the order remains active.
+    /// Use <see cref="TimeInForce.GoodTillCanceled"/> with <see cref="ExpirationTime"/> for a GTT order.
+    /// <see cref="TimeInForce.ImmediateOrCancel"/> cannot be combined with <see cref="ExpirationTime"/>.
+    /// </summary>
+    public required TimeInForce TimeInForce { get; init; }
+
+    /// <summary>
+    /// The self-trade prevention strategy for this order.
+    /// </summary>
+    public required SelfTradePreventionType SelfTradePreventionType { get; init; }
+
+    /// <summary>
+    /// Optional client-provided order ID for correlation.
+    /// </summary>
+    public string? ClientOrderId { get; init; }
+
+    /// <summary>
+    /// Optional Unix timestamp in seconds for when the order expires.
+    /// Only valid when <see cref="TimeInForce"/> is <see cref="TimeInForce.GoodTillCanceled"/>.
+    /// </summary>
+    public long? ExpirationTime { get; init; }
+
+    /// <summary>
+    /// If true, the order will only be placed if it can rest on the book (maker only).
+    /// </summary>
+    public bool? PostOnly { get; init; }
+
+    /// <summary>
+    /// If true, the order will be canceled when trading on the exchange is paused.
+    /// </summary>
+    public bool? CancelOrderOnPause { get; init; }
+
+    /// <summary>
+    /// If true, the placed count is capped by the member's current position.
+    /// </summary>
+    public bool? ReduceOnly { get; init; }
+
+    /// <summary>
+    /// The subaccount number to use for this order. 0 is the primary subaccount.
+    /// </summary>
+    public int? Subaccount { get; init; }
+
+    /// <summary>
+    /// The order group this order is part of.
+    /// </summary>
+    public string? OrderGroupId { get; init; }
+
+    /// <summary>
+    /// Identifier for an exchange shard. Defaults to 0 if unspecified.
+    /// </summary>
+    public int? ExchangeIndex { get; init; }
+}

--- a/KalshiSharp/Models/Responses/AmendOrderResponse.cs
+++ b/KalshiSharp/Models/Responses/AmendOrderResponse.cs
@@ -1,0 +1,15 @@
+﻿namespace KalshiSharp.Models.Responses
+{
+    public sealed record AmendOrderResponse
+    {
+        /// <summary>
+        /// The order before amendment
+        /// </summary>
+        public required OrderResponse OldOrder { get; set; }
+
+        /// <summary>
+        /// The order after amendment
+        /// </summary>
+        public required OrderResponse Order { get; set; }
+    }
+}

--- a/KalshiSharp/Models/Responses/AmendOrderResponseV2.cs
+++ b/KalshiSharp/Models/Responses/AmendOrderResponseV2.cs
@@ -1,0 +1,46 @@
+namespace KalshiSharp.Models.Responses;
+
+/// <summary>
+/// Response returned after successfully amending a V2 order.
+/// </summary>
+public sealed record AmendOrderResponseV2
+{
+    /// <summary>
+    /// Unique identifier of the amended order.
+    /// </summary>
+    public required string OrderId { get; init; }
+
+    /// <summary>
+    /// Matching engine timestamp at which the amend was processed, as Unix epoch milliseconds.
+    /// </summary>
+    public required long TsMs { get; init; }
+
+    /// <summary>
+    /// Client-provided order ID for correlation, if present after amendment.
+    /// </summary>
+    public string? ClientOrderId { get; init; }
+
+    /// <summary>
+    /// Number of resting contracts remaining after the amend.
+    /// Only present when the amend caused a fill or changed the resting size (e.g. "10.00").
+    /// </summary>
+    public string? RemainingCount { get; init; }
+
+    /// <summary>
+    /// Number of contracts filled as a result of the amend crossing the book.
+    /// Only present when fills occurred or remaining size changed (e.g. "10.00").
+    /// </summary>
+    public string? FillCount { get; init; }
+
+    /// <summary>
+    /// Volume-weighted average fill price for fills resulting from the amend.
+    /// Only present when fills occurred (e.g. "0.5600").
+    /// </summary>
+    public string? AverageFillPrice { get; init; }
+
+    /// <summary>
+    /// Volume-weighted average fee paid per contract for fills resulting from the amend.
+    /// Only present when fills occurred (e.g. "0.5600").
+    /// </summary>
+    public string? AverageFeePaid { get; init; }
+}

--- a/KalshiSharp/Models/Responses/CancelOrderResponseV2.cs
+++ b/KalshiSharp/Models/Responses/CancelOrderResponseV2.cs
@@ -1,0 +1,27 @@
+namespace KalshiSharp.Models.Responses;
+
+/// <summary>
+/// Response returned after successfully cancelling a V2 order.
+/// </summary>
+public sealed record CancelOrderResponseV2
+{
+    /// <summary>
+    /// Unique identifier of the cancelled order.
+    /// </summary>
+    public required string OrderId { get; init; }
+
+    /// <summary>
+    /// Number of contracts that were canceled, i.e. the remaining count at time of cancellation (e.g. "10.00").
+    /// </summary>
+    public required string ReducedBy { get; init; }
+
+    /// <summary>
+    /// Matching engine timestamp at which the cancellation was processed, as Unix epoch milliseconds.
+    /// </summary>
+    public required long TsMs { get; init; }
+
+    /// <summary>
+    /// Client-provided order ID for correlation, if supplied on the original order.
+    /// </summary>
+    public string? ClientOrderId { get; init; }
+}

--- a/KalshiSharp/Models/Responses/CreateOrderResponseV2.cs
+++ b/KalshiSharp/Models/Responses/CreateOrderResponseV2.cs
@@ -1,0 +1,44 @@
+namespace KalshiSharp.Models.Responses;
+
+/// <summary>
+/// Response returned after successfully creating a V2 order.
+/// </summary>
+public sealed record CreateOrderResponseV2
+{
+    /// <summary>
+    /// Unique identifier for the created order.
+    /// </summary>
+    public required string OrderId { get; init; }
+
+    /// <summary>
+    /// Number of contracts filled immediately upon placement (e.g. "10.00").
+    /// </summary>
+    public required string FillCount { get; init; }
+
+    /// <summary>
+    /// Number of contracts remaining after placement.
+    /// For IOC orders, reflects the final state after unfilled contracts are canceled (e.g. "10.00").
+    /// </summary>
+    public required string RemainingCount { get; init; }
+
+    /// <summary>
+    /// Matching engine timestamp at which the order was processed, as Unix epoch milliseconds.
+    /// </summary>
+    public required long TsMs { get; init; }
+
+    /// <summary>
+    /// Client-provided order ID for correlation, if supplied on the request.
+    /// </summary>
+    public string? ClientOrderId { get; init; }
+
+    /// <summary>
+    /// Volume-weighted average fill price. Only present when <see cref="FillCount"/> &gt; 0 (e.g. "0.5600").
+    /// </summary>
+    public string? AverageFillPrice { get; init; }
+
+    /// <summary>
+    /// Volume-weighted average fee paid per contract for fills resulting from this request.
+    /// Only present when <see cref="FillCount"/> &gt; 0 (e.g. "0.5600").
+    /// </summary>
+    public string? AverageFeePaid { get; init; }
+}

--- a/KalshiSharp/Models/Responses/OrderResponse.cs
+++ b/KalshiSharp/Models/Responses/OrderResponse.cs
@@ -1,4 +1,5 @@
 using KalshiSharp.Models.Enums;
+using System.Text.Json.Serialization;
 
 namespace KalshiSharp.Models.Responses;
 
@@ -48,84 +49,63 @@ public sealed record OrderResponse
     public required OrderStatus Status { get; init; }
 
     /// <summary>
-    /// Yes price in cents (1-99).
-    /// </summary>
-    public required int YesPrice { get; init; }
-
-    /// <summary>
-    /// No price in cents (derived from yes price).
-    /// </summary>
-    public required int NoPrice { get; init; }
-
-    /// <summary>
     /// Yes price in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("yes_price_dollars")]
     public string? YesPriceDollars { get; init; }
 
     /// <summary>
     /// No price in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("no_price_dollars")]
     public string? NoPriceDollars { get; init; }
 
     /// <summary>
-    /// Number of contracts filled.
+    /// Number of contracts filled - Fixed-point (2 decimals).
     /// </summary>
-    public required int FillCount { get; init; }
+    [JsonPropertyName("fill_count_fp")]
+    public string? FillCountFp { get; init; }
 
     /// <summary>
-    /// Quantity remaining (not yet filled).
+    /// Quantity remaining (not yet filled) - Fixed-point (2 decimals).
     /// </summary>
-    public required int RemainingCount { get; init; }
+    [JsonPropertyName("remaining_count_fp")]
+    public string? RemainingCountFp { get; init; }
 
     /// <summary>
-    /// Initial quantity ordered.
+    /// Initial quantity ordered - Fixed-point (2 decimals).
     /// </summary>
-    public required int InitialCount { get; init; }
-
-    /// <summary>
-    /// Taker fees in cents.
-    /// </summary>
-    public int? TakerFees { get; init; }
-
-    /// <summary>
-    /// Maker fees in cents.
-    /// </summary>
-    public int? MakerFees { get; init; }
-
-    /// <summary>
-    /// Taker fill cost in cents.
-    /// </summary>
-    public int? TakerFillCost { get; init; }
-
-    /// <summary>
-    /// Maker fill cost in cents.
-    /// </summary>
-    public int? MakerFillCost { get; init; }
+    [JsonPropertyName("initial_count_fp")]
+    public string? InitialCountFp { get; init; }
 
     /// <summary>
     /// Taker fill cost in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("taker_fill_cost_dollars")]
     public string? TakerFillCostDollars { get; init; }
 
     /// <summary>
     /// Maker fill cost in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("maker_fill_cost_dollars")]
     public string? MakerFillCostDollars { get; init; }
-
-    /// <summary>
-    /// Queue position for resting orders.
-    /// </summary>
-    public int? QueuePosition { get; init; }
 
     /// <summary>
     /// Taker fees in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("taker_fees_dollars")]
     public string? TakerFeesDollars { get; init; }
 
     /// <summary>
     /// Maker fees in dollars (string representation).
     /// </summary>
+    [JsonPropertyName("maker_fees_dollars")]
     public string? MakerFeesDollars { get; init; }
+
+    /// <summary>
+    /// Queue position for resting orders.
+    /// </summary>
+    public int? QueuePosition { get; init; }
 
     /// <summary>
     /// When the order expires.
@@ -156,4 +136,21 @@ public sealed record OrderResponse
     /// Whether to cancel order when market is paused.
     /// </summary>
     public bool? CancelOrderOnPause { get; init; }
+
+    /// <summary>
+    /// Directional exposure side of the order.
+    /// buy-yes and sell-no ? yes; buy-no and sell-yes ? no.
+    /// Prefer this over <see cref="Side"/> when present.
+    /// Will replace the legacy <see cref="Side"/> field in a future API release.
+    /// </summary>
+    [JsonPropertyName("outcome_side")]
+    public OrderSide? OutcomeSide { get; init; }
+
+    /// <summary>
+    /// Book-vocabulary equivalent of <see cref="OutcomeSide"/>.
+    /// bid = outcome yes; ask = outcome no.
+    /// Will replace the legacy <see cref="Side"/> field in a future API release.
+    /// </summary>
+    [JsonPropertyName("book_side")]
+    public OrderBookSide? BookSide { get; init; }
 }

--- a/KalshiSharp/Models/Responses/SingleResponses.cs
+++ b/KalshiSharp/Models/Responses/SingleResponses.cs
@@ -1,0 +1,34 @@
+namespace KalshiSharp.Models.Responses;
+
+/// <summary>
+/// Wrapper response for a single market from the API.
+/// </summary>
+public sealed record SingleMarketResponse
+{
+    /// <summary>
+    /// The market data.
+    /// </summary>
+    public required MarketResponse Market { get; init; }
+}
+
+/// <summary>
+/// Wrapper response for a single market from the API.
+/// </summary>
+public sealed record SingleEventResponse
+{
+    /// <summary>
+    /// The event
+    /// </summary>
+    public required EventResponse Event { get; init; }
+}
+
+/// <summary>
+/// Wrapper response for a single market from the API.
+/// </summary>
+public sealed record SingleOrderResponse
+{
+    /// <summary>
+    /// The order
+    /// </summary>
+    public required OrderResponse Order { get; init; }
+}

--- a/KalshiSharp/Models/Responses/SingleResponses.cs
+++ b/KalshiSharp/Models/Responses/SingleResponses.cs
@@ -3,17 +3,6 @@ namespace KalshiSharp.Models.Responses;
 /// <summary>
 /// Wrapper response for a single market from the API.
 /// </summary>
-public sealed record SingleMarketResponse
-{
-    /// <summary>
-    /// The market data.
-    /// </summary>
-    public required MarketResponse Market { get; init; }
-}
-
-/// <summary>
-/// Wrapper response for a single market from the API.
-/// </summary>
 public sealed record SingleEventResponse
 {
     /// <summary>

--- a/KalshiSharp/Rest/IKalshiClient.cs
+++ b/KalshiSharp/Rest/IKalshiClient.cs
@@ -33,6 +33,11 @@ public interface IKalshiClient : IDisposable
     IOrderClient Orders { get; }
 
     /// <summary>
+    /// Gets the V2 orders client for the events orders endpoint.
+    /// </summary>
+    IOrderClientV2 OrdersV2 { get; }
+
+    /// <summary>
     /// Gets the portfolio client for balance, positions, and fills endpoints.
     /// </summary>
     IPortfolioClient Portfolio { get; }

--- a/KalshiSharp/Rest/KalshiClient.cs
+++ b/KalshiSharp/Rest/KalshiClient.cs
@@ -23,6 +23,7 @@ public sealed class KalshiClient : IKalshiClient
     private readonly IMarketClient _markets;
     private readonly IEventClient _events;
     private readonly IOrderClient _orders;
+    private readonly IOrderClientV2 _ordersV2;
     private readonly IPortfolioClient _portfolio;
     private readonly IUserClient _users;
 
@@ -82,6 +83,7 @@ public sealed class KalshiClient : IKalshiClient
         _markets = new MarketClient(kalshiHttpClient);
         _events = new EventClient(kalshiHttpClient);
         _orders = new OrderClient(kalshiHttpClient);
+        _ordersV2 = new OrderClientV2(kalshiHttpClient);
         _portfolio = new PortfolioClient(kalshiHttpClient);
         _users = new UserClient(kalshiHttpClient);
     }
@@ -99,6 +101,7 @@ public sealed class KalshiClient : IKalshiClient
         _markets = new MarketClient(httpClient);
         _events = new EventClient(httpClient);
         _orders = new OrderClient(httpClient);
+        _ordersV2 = new OrderClientV2(httpClient);
         _portfolio = new PortfolioClient(httpClient);
         _users = new UserClient(httpClient);
     }
@@ -111,6 +114,7 @@ public sealed class KalshiClient : IKalshiClient
     /// <param name="markets">The markets client.</param>
     /// <param name="events">The events client.</param>
     /// <param name="orders">The orders client.</param>
+    /// <param name="ordersV2">The orders V2 client.</param>
     /// <param name="portfolio">The portfolio client.</param>
     /// <param name="users">The users client.</param>
     public KalshiClient(
@@ -118,6 +122,7 @@ public sealed class KalshiClient : IKalshiClient
         IMarketClient markets,
         IEventClient events,
         IOrderClient orders,
+        IOrderClientV2 ordersV2,
         IPortfolioClient portfolio,
         IUserClient users)
     {
@@ -125,6 +130,7 @@ public sealed class KalshiClient : IKalshiClient
         _markets = markets ?? throw new ArgumentNullException(nameof(markets));
         _events = events ?? throw new ArgumentNullException(nameof(events));
         _orders = orders ?? throw new ArgumentNullException(nameof(orders));
+        _ordersV2 = ordersV2 ?? throw new ArgumentNullException(nameof(ordersV2));
         _portfolio = portfolio ?? throw new ArgumentNullException(nameof(portfolio));
         _users = users ?? throw new ArgumentNullException(nameof(users));
     }
@@ -166,6 +172,16 @@ public sealed class KalshiClient : IKalshiClient
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
             return _orders;
+        }
+    }
+
+    /// <inheritdoc />
+    public IOrderClientV2 OrdersV2
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _ordersV2;
         }
     }
 

--- a/KalshiSharp/Rest/Orders/IOrderClient.cs
+++ b/KalshiSharp/Rest/Orders/IOrderClient.cs
@@ -23,7 +23,7 @@ public interface IOrderClient
     /// <param name="request">The amendment request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The updated order details.</returns>
-    Task<OrderResponse> AmendOrderAsync(string orderId, AmendOrderRequest request, CancellationToken cancellationToken = default);
+    Task<AmendOrderResponse> AmendOrderAsync(string orderId, AmendOrderRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels an existing order.

--- a/KalshiSharp/Rest/Orders/IOrderClientV2.cs
+++ b/KalshiSharp/Rest/Orders/IOrderClientV2.cs
@@ -1,0 +1,38 @@
+﻿using KalshiSharp.Models.Requests;
+using KalshiSharp.Models.Responses;
+
+namespace KalshiSharp.Rest.Orders
+{
+    /// <summary>
+    /// Client for order management operations on the Kalshi exchange (V2 events endpoint).
+    /// </summary>
+    public interface IOrderClientV2
+    {
+        /// <summary>
+        /// Creates a new order.
+        /// </summary>
+        /// <param name="request">The order creation request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created order details.</returns>
+        Task<CreateOrderResponseV2> CreateOrderAsync(CreateOrderRequestV2 request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels an existing order.
+        /// </summary>
+        /// <param name="orderId">The order ID to cancel.</param>
+        /// <param name="query">Optional query parameters (subaccount, exchange shard).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The cancellation details.</returns>
+        Task<CancelOrderResponseV2> CancelOrderAsync(string orderId, CancelOrderQueryV2? query = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Amends an existing order (price and/or quantity).
+        /// </summary>
+        /// <param name="orderId">The order ID to amend.</param>
+        /// <param name="request">The amendment request.</param>
+        /// <param name="subaccount">Optional subaccount number (0 for primary, 1-63 for subaccounts).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The amendment details.</returns>
+        Task<AmendOrderResponseV2> AmendOrderAsync(string orderId, AmendOrderRequestV2 request, int? subaccount = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/KalshiSharp/Rest/Orders/OrderClient.cs
+++ b/KalshiSharp/Rest/Orders/OrderClient.cs
@@ -23,7 +23,7 @@ internal sealed class OrderClient : IOrderClient
     }
 
     /// <inheritdoc />
-    public Task<OrderResponse> CreateOrderAsync(CreateOrderRequest request, CancellationToken cancellationToken = default)
+    public async Task<OrderResponse> CreateOrderAsync(CreateOrderRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -34,27 +34,28 @@ internal sealed class OrderClient : IOrderClient
             Content = request
         };
 
-        return _httpClient.SendAsync<OrderResponse>(httpRequest, cancellationToken);
+        var response = await _httpClient.SendAsync<SingleOrderResponse>(httpRequest, cancellationToken);
+        return response.Order;
     }
 
     /// <inheritdoc />
-    public Task<OrderResponse> AmendOrderAsync(string orderId, AmendOrderRequest request, CancellationToken cancellationToken = default)
+    public Task<AmendOrderResponse> AmendOrderAsync(string orderId, AmendOrderRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
         ArgumentNullException.ThrowIfNull(request);
 
         var httpRequest = new KalshiRequest
         {
-            Method = HttpMethod.Put,
-            Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}",
+            Method = HttpMethod.Post, // even though we're updating an existing resource, Kalshi expects this as an POST.
+            Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}/amend",
             Content = request
         };
 
-        return _httpClient.SendAsync<OrderResponse>(httpRequest, cancellationToken);
+        return _httpClient.SendAsync<AmendOrderResponse>(httpRequest, cancellationToken);
     }
 
     /// <inheritdoc />
-    public Task<OrderResponse> CancelOrderAsync(string orderId, CancellationToken cancellationToken = default)
+    public async Task<OrderResponse> CancelOrderAsync(string orderId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
 
@@ -64,11 +65,12 @@ internal sealed class OrderClient : IOrderClient
             Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}"
         };
 
-        return _httpClient.SendAsync<OrderResponse>(httpRequest, cancellationToken);
+        var response = await _httpClient.SendAsync<SingleOrderResponse>(httpRequest, cancellationToken);
+        return response.Order;
     }
 
     /// <inheritdoc />
-    public Task<OrderResponse> GetOrderAsync(string orderId, CancellationToken cancellationToken = default)
+    public async Task<OrderResponse> GetOrderAsync(string orderId, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
 
@@ -78,7 +80,8 @@ internal sealed class OrderClient : IOrderClient
             Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}"
         };
 
-        return _httpClient.SendAsync<OrderResponse>(httpRequest, cancellationToken);
+        var response = await _httpClient.SendAsync<SingleOrderResponse>(httpRequest, cancellationToken);
+        return response.Order;
     }
 
     /// <inheritdoc />

--- a/KalshiSharp/Rest/Orders/OrderClientV2.cs
+++ b/KalshiSharp/Rest/Orders/OrderClientV2.cs
@@ -1,0 +1,80 @@
+﻿using KalshiSharp.Http;
+using KalshiSharp.Models.Common;
+using KalshiSharp.Models.Requests;
+using KalshiSharp.Models.Responses;
+
+namespace KalshiSharp.Rest.Orders;
+
+/// <summary>
+/// Implementation of the V2 order client for the events orders endpoint.
+/// </summary>
+internal sealed class OrderClientV2 : IOrderClientV2
+{
+    private const string BasePath = "/trade-api/v2/portfolio/events/orders";
+
+    private readonly IKalshiHttpClient _httpClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderClientV2"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client.</param>
+    public OrderClientV2(IKalshiHttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <inheritdoc />
+    public Task<CreateOrderResponseV2> CreateOrderAsync(CreateOrderRequestV2 request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var httpRequest = new KalshiRequest
+        {
+            Method = HttpMethod.Post,
+            Path = BasePath,
+            Content = request
+        };
+
+        return _httpClient.SendAsync<CreateOrderResponseV2>(httpRequest, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<CancelOrderResponseV2> CancelOrderAsync(string orderId, CancelOrderQueryV2? query = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+
+        var queryString = query?.ToQueryString() ?? string.Empty;
+
+        var httpRequest = new KalshiRequest
+        {
+            Method = HttpMethod.Delete,
+            Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}{queryString}"
+        };
+
+        return _httpClient.SendAsync<CancelOrderResponseV2>(httpRequest, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<AmendOrderResponseV2> AmendOrderAsync(string orderId, AmendOrderRequestV2 request, int? subaccount = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orderId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var queryString = string.Empty;
+        if (subaccount.HasValue)
+        {
+            var builder = new QueryStringBuilder();
+            builder.AppendIfNotNull("subaccount", subaccount);
+            queryString = builder.Build();
+        }
+
+        var httpRequest = new KalshiRequest
+        {
+            Method = HttpMethod.Post,
+            Path = $"{BasePath}/{Uri.EscapeDataString(orderId)}/amend{queryString}",
+            Content = request
+        };
+
+        return _httpClient.SendAsync<AmendOrderResponseV2>(httpRequest, cancellationToken);
+    }
+}

--- a/KalshiSharp/WebSockets/KalshiWebSocketClient.cs
+++ b/KalshiSharp/WebSockets/KalshiWebSocketClient.cs
@@ -294,8 +294,7 @@ public sealed partial class KalshiWebSocketClient : IKalshiWebSocketClient
 
         try
         {
-            while (!cancellationToken.IsCancellationRequested &&
-                   _connection.WebSocketState == WebSocketState.Open)
+            while (!cancellationToken.IsCancellationRequested && _connection.WebSocketState == WebSocketState.Open)
             {
                 messageBuffer.SetLength(0);
 
@@ -332,7 +331,7 @@ public sealed partial class KalshiWebSocketClient : IKalshiWebSocketClient
             await HandleDisconnectAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
-        {
+        {            
             LogReceiveError(ex);
             await HandleDisconnectAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
### Background
Kalshi's specs have change for the orders endpoint. This PR updates the OrdersClient and respective data models with respect to those changes.

### Change Summary
- [x] Updated OrderClient
- [x] Updated request and response models.
- [x] Updated tests.
- [x] Added new tests.

### Notes
* [PR17](https://github.com/hurley451/KalshiSharp/pull/17) needs to be merged first.
* Changes were manually tested.
* **Important!** - I v2'd the OrderClient because, at the time I wrote this PR, Kalshi kept both versions of the endpoint. However, it seems that the v1 has been completely deprecated and is no longer accessible. It may make sense to simply replace the old interface instead of keeping a v2 interface. Thoughts?