### PR TITLE
Fix duplicate symbol package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,10 +115,13 @@ jobs:
         shell: bash
         env:
           NUGET_API_KEY: ${{ steps.nuget.outputs.NUGET_API_KEY }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.value }}
         run: |
-          dotnet nuget push artifacts/packages/*.nupkg \
+          dotnet nuget push "artifacts/packages/KalshiSharp.${PACKAGE_VERSION}.nupkg" \
             --api-key "$NUGET_API_KEY" \
-            --source https://api.nuget.org/v3/index.json
-          dotnet nuget push artifacts/packages/*.snupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+          dotnet nuget push "artifacts/packages/KalshiSharp.${PACKAGE_VERSION}.snupkg" \
             --api-key "$NUGET_API_KEY" \
-            --source https://api.nuget.org/v3/index.json
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate


### PR DESCRIPTION
Summary:
- publish the package and symbols package by exact filename
- make release reruns idempotent with `--skip-duplicate`

Verification:
- workflow YAML parses successfully
- `git diff --check` passes
- v1.1.0 run proved the previous `*.nupkg` glob uploaded the `.snupkg` before the explicit symbols command, causing a duplicate 409

Risk: release-workflow-only change; no package or SDK code changes.