### PR TITLE
Expose exchange index on WebSocket fills

### DIFF
--- a/KalshiSharp.Tests/WebSockets/WebSocketReplayTests.cs
+++ b/KalshiSharp.Tests/WebSockets/WebSocketReplayTests.cs
@@ -522,6 +522,7 @@ public sealed class WebSocketReplayTests : IAsyncDisposable
                 "trade_id": "trade-current",
                 "order_id": "order-current",
                 "market_ticker": "KXTEST-26AUG19",
+                "exchange_index": 1,
                 "is_taker": true,
                 "outcome_side": "yes",
                 "book_side": "bid",
@@ -557,6 +558,7 @@ public sealed class WebSocketReplayTests : IAsyncDisposable
         order.Message.LastUpdatedTsMs.Should().Be(1787155200456);
         fill.Message.CountFp.Should().Be("6.00");
         fill.Message.OutcomeSide.Should().Be(OrderSide.Yes);
+        fill.Message.ExchangeIndex.Should().Be(1);
         position.Message.PositionFp.Should().Be("6.00");
     }
 

--- a/KalshiSharp/Models/WebSocket/FillUpdate.cs
+++ b/KalshiSharp/Models/WebSocket/FillUpdate.cs
@@ -33,6 +33,12 @@ public sealed record FillUpdate : WebSocketMessage<FillUpdate.MessageBody>
             public required string MarketTicker { get; init; }
 
             /// <summary>
+            /// Exchange shard where the fill occurred.
+            /// </summary>
+            [JsonPropertyName("exchange_index")]
+            public int? ExchangeIndex { get; init; }
+
+            /// <summary>
             /// If you were a taker on this fill.
             /// </summary>
             [JsonPropertyName("is_taker")]


### PR DESCRIPTION
## Summary

- expose the new `exchange_index` field on private WebSocket fill updates
- cover the current payload in the focused replay test

## Verification

- `dotnet build KalshiSharp.sln --no-restore --configuration Release -p:EnablePackageValidation=false --disable-build-servers -m:1`
- `dotnet test KalshiSharp.sln --no-build --configuration Release` (225 passed)
- coverage gate: 70.70% line coverage (69% required)
- `dotnet pack KalshiSharp/KalshiSharp.csproj --no-build --configuration Release --output artifacts/packages`

## Notes

Additive and backward-compatible. Older fill payloads can continue omitting the nullable field.

Relates to #23.

Source: https://docs.kalshi.com/websockets/user-fills